### PR TITLE
Release iceberg python module as py-iceberg

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,6 +42,7 @@ jobs:
         python-version: ${{ matrix.python }}
     - working-directory: ./python
       run: |
+        echo "__version__ = '0.0.0'" >> iceberg/__init__.py
         pip install -e .[dev]
         pip install -U tox-gh-actions
     - working-directory: ./python

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,11 +14,27 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
 
+from setuptools import find_packages
 from setuptools import setup
 
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version(file_path):
+    with open(os.path.join(HERE, file_path), 'r') as f:
+        for line in f.readlines():
+            print(line)
+            if line.startswith('__version__'):
+                return line.split("'")[1]
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(
-    name='iceberg',
+    name='py-iceberg',
+    packages=find_packages(exclude=["tests*"]),
+    version=get_version('iceberg/__init__.py'),
     maintainer='Apache Iceberg Devs',
     author_email='dev@iceberg.apache.org',
     description='Iceberg is a new table format for storing large, slow-moving tabular data',


### PR DESCRIPTION
The upstream is planning to release iceberg python module as "py-iceberg" in future releases, this diff is to support this in 0.12.1 release. The diff is tested with our build pipeline and made sure the py package is able to installed and used successfully.

The rename of the package caused setup.py not able to fetch the version we specify in iceberg/__init__.py file, thus we will need to add a function inside setup.py to get that.