### PR TITLE
Core: Fix history timestamp for rollbacks (#4135)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -282,14 +282,18 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
           .run(taskOps -> {
             Snapshot newSnapshot = apply();
             newSnapshotId.set(newSnapshot.snapshotId());
-            TableMetadata updated;
-            if (stageOnly) {
-              updated = base.addStagedSnapshot(newSnapshot);
+            TableMetadata.Builder update = TableMetadata.buildFrom(base);
+            if (base.snapshot(newSnapshot.snapshotId()) != null) {
+              // this is a rollback or cherrypick operation
+              update.setCurrentSnapshot(newSnapshot.snapshotId());
+            } else if (stageOnly) {
+              update.addSnapshot(newSnapshot);
             } else {
-              updated = base.replaceCurrentSnapshot(newSnapshot);
+              update.setCurrentSnapshot(newSnapshot);
             }
 
-            if (updated == base) {
+            TableMetadata updated = update.build();
+            if (updated.changes().isEmpty()) {
               // do not commit if the metadata has not changed. for example, this may happen when setting the current
               // snapshot to an ID that is already current. note that this check uses identity.
               return;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -501,6 +501,10 @@ public class TableMetadata implements Serializable {
     return new Builder(this).setCurrentSnapshot(snapshot).build();
   }
 
+  public TableMetadata replaceCurrentSnapshot(long snapshotId) {
+    return new Builder(this).setCurrentSnapshot(snapshotId).build();
+  }
+
   public TableMetadata removeSnapshotsIf(Predicate<Snapshot> removeIf) {
     List<Snapshot> toRemove = snapshots.stream().filter(removeIf).collect(Collectors.toList());
     return new Builder(this).removeSnapshots(toRemove).build();


### PR DESCRIPTION
(cherry picked from commit e2af91c64a181ac231468d8ebc957c3b9558586d)