### PR TITLE
[python legacy] use process pool instead of thread pool for files planning

### DIFF
--- a/python_legacy/iceberg/core/data_table_scan.py
+++ b/python_legacy/iceberg/core/data_table_scan.py
@@ -18,7 +18,7 @@
 import itertools
 import logging
 from multiprocessing import cpu_count
-from multiprocessing.dummy import Pool
+from multiprocessing import Pool
 
 from iceberg.api.expressions import (InclusiveManifestEvaluator,
                                      ResidualEvaluator)


### PR DESCRIPTION
As title.