### PR TITLE
Fix concurrent transactions overwriting commits by adding hive lock heartbeats.

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -48,6 +48,7 @@ import org.mockito.invocation.InvocationOnMock;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -260,6 +261,6 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
 
     spyOps.doCommit(metadataV2, metadataV1);
 
-    verify(spyClient, times(2)).heartbeat(eq(0L), eq(dummyLockId));
+    verify(spyClient, atLeastOnce()).heartbeat(eq(0L), eq(dummyLockId));
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -260,6 +260,6 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
 
     spyOps.doCommit(metadataV2, metadataV1);
 
-    verify(spyClient, times(1)).heartbeat(eq(0L), eq(dummyLockId));
+    verify(spyClient, times(2)).heartbeat(eq(0L), eq(dummyLockId));
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -242,6 +242,7 @@ public class TestHiveMetastore {
     conf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname, "false");
     conf.set(HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname, "false");
     conf.set("iceberg.hive.client-pool-size", "2");
+    conf.set(HiveConf.ConfVars.HIVE_TXN_TIMEOUT.varname, "1s");
   }
 
   private static void setupMetastoreDB(String dbURL) throws SQLException, IOException {


### PR DESCRIPTION
When using Hive Metastore catalog, it is possible that longer transactions can take longer than [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout) of the Hive Metastore (hive.txn.timeout or metastore.txn.timeout in the newer versions). In those cases, concurrent transactions can overwrite each other leading to data corruption. This change fixes concurrent transactions overwriting commits by adding hive lock heartbeats.