### PR TITLE
Allow ignoring field ids from parquet files in add files APIs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -345,4 +345,6 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  public static final String THRIFT_TYPE = "thrift_type";
 }

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFact
 import org.apache.iceberg.util.Tasks;
 
 public class TableMigrationUtil {
+  public static final String IGNORE_PARQUET_FIELD_IDS = "ignore.parquet.file.ids";
   private static final PathFilter HIDDEN_PATH_FILTER =
       p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
@@ -165,7 +166,11 @@ public class TableMigrationUtil {
       Path path, Configuration conf, MetricsConfig metricsSpec, NameMapping mapping) {
     try {
       InputFile file = HadoopInputFile.fromPath(path, conf);
-      return ParquetUtil.fileMetrics(file, metricsSpec, mapping);
+      return ParquetUtil.fileMetrics(
+          file,
+          metricsSpec,
+          mapping,
+          Boolean.parseBoolean(conf.get(IGNORE_PARQUET_FIELD_IDS, "false")));
     } catch (UncheckedIOException e) {
       throw new RuntimeException("Unable to read the metrics of the Parquet file: " + path, e);
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -74,8 +74,14 @@ public class ParquetUtil {
 
   public static Metrics fileMetrics(
       InputFile file, MetricsConfig metricsConfig, NameMapping nameMapping) {
+    return fileMetrics(file, metricsConfig, nameMapping, false);
+  }
+
+  public static Metrics fileMetrics(
+      InputFile file, MetricsConfig metricsConfig, NameMapping nameMapping, boolean ignoreFileIds) {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
-      return footerMetrics(reader.getFooter(), Stream.empty(), metricsConfig, nameMapping);
+      return footerMetrics(
+          reader.getFooter(), Stream.empty(), metricsConfig, nameMapping, ignoreFileIds);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
     }
@@ -92,6 +98,16 @@ public class ParquetUtil {
       Stream<FieldMetrics<?>> fieldMetrics,
       MetricsConfig metricsConfig,
       NameMapping nameMapping) {
+    return footerMetrics(metadata, fieldMetrics, metricsConfig, nameMapping, false);
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  public static Metrics footerMetrics(
+      ParquetMetadata metadata,
+      Stream<FieldMetrics<?>> fieldMetrics,
+      MetricsConfig metricsConfig,
+      NameMapping nameMapping,
+      boolean ignoreFileIds) {
     Preconditions.checkNotNull(fieldMetrics, "fieldMetrics should not be null");
 
     long rowCount = 0;
@@ -103,7 +119,7 @@ public class ParquetUtil {
     Set<Integer> missingStats = Sets.newHashSet();
 
     // ignore metrics for fields we failed to determine reliable IDs
-    MessageType parquetTypeWithIds = getParquetTypeWithIds(metadata, nameMapping);
+    MessageType parquetTypeWithIds = getParquetTypeWithIds(metadata, nameMapping, ignoreFileIds);
     Schema fileSchema = ParquetSchemaUtil.convertAndPrune(parquetTypeWithIds);
 
     Map<Integer, FieldMetrics<?>> fieldMetricsMap =
@@ -209,9 +225,14 @@ public class ParquetUtil {
 
   private static MessageType getParquetTypeWithIds(
       ParquetMetadata metadata, NameMapping nameMapping) {
+    return getParquetTypeWithIds(metadata, nameMapping, false);
+  }
+
+  private static MessageType getParquetTypeWithIds(
+      ParquetMetadata metadata, NameMapping nameMapping, boolean ignoreFileIds) {
     MessageType type = metadata.getFileMetaData().getSchema();
 
-    if (ParquetSchemaUtil.hasIds(type)) {
+    if (!ignoreFileIds && ParquetSchemaUtil.hasIds(type)) {
       return type;
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -62,6 +63,7 @@ import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
+import org.apache.parquet.Strings;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -511,9 +513,13 @@ public class SparkTableUtil {
       PartitionSpec spec = PartitionSpec.unpartitioned();
       Configuration conf = spark.sessionState().newHadoopConf();
       MetricsConfig metricsConfig = MetricsConfig.forTable(targetTable);
+      boolean isThriftBackedTable =
+          !Strings.isNullOrEmpty(targetTable.properties().get("thrift_type"));
       String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
       NameMapping nameMapping =
-          nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;
+          isThriftBackedTable
+              ? MappingUtil.create(targetTable.schema())
+              : (nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null);
 
       List<DataFile> files =
           TableMigrationUtil.listPartition(
@@ -571,7 +577,12 @@ public class SparkTableUtil {
       PartitionSpec spec,
       String stagingDir,
       boolean checkDuplicateFiles) {
+    boolean isThriftBackedTable =
+        !Strings.isNullOrEmpty(targetTable.properties().get("thrift_type"));
     Configuration conf = spark.sessionState().newHadoopConf();
+    if (isThriftBackedTable) {
+      conf.set(TableMigrationUtil.IGNORE_PARQUET_FIELD_IDS, "true");
+    }
     SerializableConfiguration serializableConf = new SerializableConfiguration(conf);
     int parallelism =
         Math.min(
@@ -580,7 +591,9 @@ public class SparkTableUtil {
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(targetTable.properties());
     String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     NameMapping nameMapping =
-        nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;
+        isThriftBackedTable
+            ? MappingUtil.create(targetTable.schema())
+            : (nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null);
 
     JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
     JavaRDD<SparkPartition> partitionRDD = sparkContext.parallelize(partitions, parallelism);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -514,7 +514,7 @@ public class SparkTableUtil {
       Configuration conf = spark.sessionState().newHadoopConf();
       MetricsConfig metricsConfig = MetricsConfig.forTable(targetTable);
       boolean isThriftBackedTable =
-          !Strings.isNullOrEmpty(targetTable.properties().get("thrift_type"));
+          !Strings.isNullOrEmpty(targetTable.properties().get(TableProperties.THRIFT_TYPE));
       String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
       NameMapping nameMapping =
           isThriftBackedTable
@@ -578,7 +578,7 @@ public class SparkTableUtil {
       String stagingDir,
       boolean checkDuplicateFiles) {
     boolean isThriftBackedTable =
-        !Strings.isNullOrEmpty(targetTable.properties().get("thrift_type"));
+        !Strings.isNullOrEmpty(targetTable.properties().get(TableProperties.THRIFT_TYPE));
     Configuration conf = spark.sessionState().newHadoopConf();
     if (isThriftBackedTable) {
       conf.set(TableMigrationUtil.IGNORE_PARQUET_FIELD_IDS, "true");

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -61,7 +61,8 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     this.expectedSchema = expectedSchema;
     this.nameMapping = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     this.caseSensitive = caseSensitive;
-    this.isThriftBackedTable = !Strings.isNullOrEmpty(table.properties().get(TableProperties.THRIFT_TYPE));
+    this.isThriftBackedTable =
+        !Strings.isNullOrEmpty(table.properties().get(TableProperties.THRIFT_TYPE));
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -61,7 +61,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     this.expectedSchema = expectedSchema;
     this.nameMapping = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     this.caseSensitive = caseSensitive;
-    this.isThriftBackedTable = !Strings.isNullOrEmpty(table.properties().get("thrift_type"));
+    this.isThriftBackedTable = !Strings.isNullOrEmpty(table.properties().get(TableProperties.THRIFT_TYPE));
   }
 
   @Override


### PR DESCRIPTION
This is to allow adding parquet files written by parquet writers that can generate parquet schema with field ids repeated at different levels. Iceberg assumes that parquet schema always have unique field ids.