### PR TITLE
[backport] Build: Let revapi compare API compatibility against apache-iceberg-1.0.0 (#6053)

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -28,6 +28,7 @@ on:
   pull_request:
     paths:
       - 'api/**'
+      - '.palantir/revapi.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,5 +1,3 @@
-versionOverrides:
-  org.apache.iceberg:iceberg-api:apache-iceberg-0.14.0: "0.14.0"
 acceptedBreaks:
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:

--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,12 @@ project(':iceberg-bundled-guava') {
 project(':iceberg-api') {
   apply plugin: 'com.palantir.revapi'
 
+  revapi {
+    oldGroup = "org.apache.iceberg"
+    oldName = "iceberg-api"
+    oldVersion = "1.0.0"
+  }
+
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compileOnly "com.google.errorprone:error_prone_annotations"


### PR DESCRIPTION
(cherry picked from commit c7aa5c878faec17bca2c516bcdef51914c1bc63a)