### PR TITLE
update iceberg-flink-runtime build so that the jar is compatible with…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,7 @@ import groovy.transform.Memoized
 
 buildscript {
   repositories {
-    jcenter()
     gradlePluginPortal()
-    maven { url "http://palantir.bintray.com/releases" }
-    maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
     classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
@@ -64,7 +61,6 @@ allprojects {
   group = "org.apache.iceberg"
   version = getProjectVersion()
   repositories {
-    maven { url  "http://palantir.bintray.com/releases" }
     mavenCentral()
     mavenLocal()
   }
@@ -315,7 +311,10 @@ project(':iceberg-flink') {
     compile project(':iceberg-data')
     compile project(':iceberg-orc')
     compile project(':iceberg-parquet')
-    compile project(':iceberg-hive-metastore')
+    compile (project(':iceberg-hive-metastore')) {
+      exclude group: 'org.apache.hive', module: 'hive-metastore'
+      exclude group: 'org.apache.hadoop', module: 'hadoop-client'
+    }
 
     compileOnly "org.apache.flink:flink-streaming-java_2.12"
     compileOnly "org.apache.flink:flink-streaming-java_2.12::tests"
@@ -388,6 +387,10 @@ project(':iceberg-flink-runtime') {
       exclude group: 'org.apache.commons'
       exclude group: 'commons-pool'
       exclude group: 'commons-codec'
+      exclude group: 'commons-logging'
+      exclude group: 'commons-lang'
+      exclude group: 'commons-cli'
+      exclude group: 'commons-dbcp'
       exclude group: 'org.xerial.snappy'
       exclude group: 'javax.xml.bind'
       exclude group: 'javax.annotation'
@@ -424,6 +427,8 @@ project(':iceberg-flink-runtime') {
     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+    relocate 'org.apache.thrift', 'org.apache.hive.org.apache.thrift'
+    relocate 'com.facebook.fb303', 'org.apache.hive.com.facebook.fb303'
 
     classifier null
   }


### PR DESCRIPTION
update iceberg-flink-runtime build so that the jar is compatible with pinterest internal runtime env (flink 1.11)

