### PR TITLE
backport https://github.com/apache/iceberg/pull/5126 

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -210,7 +210,12 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
       this.closed = true;
       flushRowGroup(true);
       writeStore.close();
-      writer.end(metadata);
+      if (writer != null) {
+        writer.end(metadata);
+      }
+      if (compressor != null) {
+        compressor.release();
+      }
     }
   }
 }


### PR DESCRIPTION
to close compressor and avoid memory leak (found in Flink iceberg connector)