### PR TITLE
[Iceberg thrift] set IGNORE_PARQUET_FIELD_IDS for unpartitioned table importing (#29)

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -518,6 +518,9 @@ public class SparkTableUtil {
       MetricsConfig metricsConfig = MetricsConfig.forTable(targetTable);
       boolean isThriftBackedTable =
           !Strings.isNullOrEmpty(targetTable.properties().get(TableProperties.THRIFT_TYPE));
+      if (isThriftBackedTable) {
+        conf.set(TableMigrationUtil.IGNORE_PARQUET_FIELD_IDS, "true");
+      }
       String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
       NameMapping nameMapping =
           isThriftBackedTable


### PR DESCRIPTION
(cherry picked from commit 612ebf9a22a485aa2cc78884419b3def38e41991)