### PR TITLE
[Iceberg thrift] support case insensitive id assignment for thrift backed Iceberg Parquet table (#28)

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ApplyNameMapping.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ApplyNameMapping.java
@@ -164,4 +164,8 @@ class ApplyNameMapping extends ParquetTypeVisitor<Type> {
     list.add(name);
     return list.toArray(new String[0]);
   }
+
+  Deque<String> getFieldNames() {
+    return fieldNames;
+  }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ApplyNameMappingCaseInsensitive.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ApplyNameMappingCaseInsensitive.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+class ApplyNameMappingCaseInsensitive extends ApplyNameMapping {
+  ApplyNameMappingCaseInsensitive(NameMapping nameMapping) {
+    super(nameMapping);
+  }
+
+  @Override
+  protected String[] currentPath() {
+    return Lists.newArrayList(this.getFieldNames().descendingIterator()).stream()
+        .map(String::toLowerCase)
+        .toArray(String[]::new);
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -133,6 +133,12 @@ public class ParquetSchemaUtil {
     return (MessageType) ParquetTypeVisitor.visit(fileSchema, new ApplyNameMapping(nameMapping));
   }
 
+  public static MessageType applyNameMappingCaseInsensitive(
+      MessageType fileSchema, NameMapping nameMapping) {
+    return (MessageType)
+        ParquetTypeVisitor.visit(fileSchema, new ApplyNameMappingCaseInsensitive(nameMapping));
+  }
+
   public static class HasIds extends ParquetTypeVisitor<Boolean> {
     @Override
     public Boolean message(MessageType message, List<Boolean> fields) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -240,6 +240,9 @@ public class ParquetUtil {
     }
 
     if (nameMapping != null) {
+      if (ignoreFileIds) {
+        return ParquetSchemaUtil.applyNameMappingCaseInsensitive(type, nameMapping);
+      }
       return ParquetSchemaUtil.applyNameMapping(type, nameMapping);
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -87,7 +87,7 @@ class ReadConf<T> {
     if (isThriftBackedTable) {
       NameMapping nameMappingFromExpectedSchema = MappingUtil.create(expectedSchema);
       fileSchema =
-          ParquetSchemaUtil.applyNameMapping(
+          ParquetSchemaUtil.applyNameMappingCaseInsensitive(
               RemoveIds.removeIds(fileSchema), nameMappingFromExpectedSchema);
     }
     if (ParquetSchemaUtil.hasIds(fileSchema)) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -128,6 +128,32 @@ public class TestParquetSchemaUtil {
   }
 
   @Test
+  public void testAssignIdsByNameMappingCaseInsensitive() {
+    Types.StructType structTypeCaseInsensitive =
+        Types.StructType.of(required(0, "id", Types.LongType.get()));
+    Schema schemaCaseInsensitive =
+        new Schema(
+            TypeUtil.assignFreshIds(
+                    structTypeCaseInsensitive, new AtomicInteger(0)::incrementAndGet)
+                .asStructType()
+                .fields());
+    NameMapping nameMappingCaseInsensitive = MappingUtil.create(schemaCaseInsensitive);
+
+    Types.StructType structType = Types.StructType.of(required(0, "ID", Types.LongType.get()));
+    Schema schema =
+        new Schema(
+            TypeUtil.assignFreshIds(structType, new AtomicInteger(0)::incrementAndGet)
+                .asStructType()
+                .fields());
+    MessageType messageTypeWithIds = ParquetSchemaUtil.convert(schema, "parquet_type");
+    MessageType messageTypeWithIdsFromNameMapping =
+        ParquetSchemaUtil.applyNameMappingCaseInsensitive(
+            RemoveIds.removeIds(messageTypeWithIds), nameMappingCaseInsensitive);
+
+    Assert.assertEquals(messageTypeWithIds, messageTypeWithIdsFromNameMapping);
+  }
+
+  @Test
   public void testSchemaConversionWithoutAssigningIds() {
     MessageType messageType =
         new MessageType(

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -86,7 +86,8 @@ public class SparkParquetReaders {
     if (isThriftBackedTable) {
       NameMapping nameMapping = MappingUtil.create(expectedSchema);
       updatedFileSchema =
-          ParquetSchemaUtil.applyNameMapping(RemoveIds.removeIds(fileSchema), nameMapping);
+          ParquetSchemaUtil.applyNameMappingCaseInsensitive(
+              RemoveIds.removeIds(fileSchema), nameMapping);
     }
 
     return buildReader(expectedSchema, updatedFileSchema, idToConstant);


### PR DESCRIPTION
(cherry picked from commit 165c5e8b246ac729d78362c2405e69d8685fc1e1)