### PR TITLE
Allow snapshot/ migrate Hive table with partition value contains slash

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -58,12 +58,17 @@ public class DataFiles {
   }
 
   static PartitionData fillFromPath(PartitionSpec spec, String partitionPath, PartitionData reuse) {
+    return fillFromPath(spec, partitionPath, reuse, "/");
+  }
+
+  static PartitionData fillFromPath(
+      PartitionSpec spec, String partitionPath, PartitionData reuse, String partitionPathSplitter) {
     PartitionData data = reuse;
     if (data == null) {
       data = newPartitionData(spec);
     }
 
-    String[] partitions = partitionPath.split("/", -1);
+    String[] partitions = partitionPath.split(partitionPathSplitter, -1);
     Preconditions.checkArgument(
         partitions.length <= spec.fields().size(),
         "Invalid partition data, too many fields (expecting %s): %s",
@@ -239,11 +244,16 @@ public class DataFiles {
     }
 
     public Builder withPartitionPath(String newPartitionPath) {
+      return withPartitionPath(newPartitionPath, "/");
+    }
+
+    public Builder withPartitionPath(String newPartitionPath, String newPartitionPathSplitter) {
       Preconditions.checkArgument(
           isPartitioned || newPartitionPath.isEmpty(),
           "Cannot add partition data for an unpartitioned table");
       if (!newPartitionPath.isEmpty()) {
-        this.partitionData = fillFromPath(spec, newPartitionPath, partitionData);
+        this.partitionData =
+            fillFromPath(spec, newPartitionPath, partitionData, newPartitionPathSplitter);
       }
       return this;
     }


### PR DESCRIPTION
Iceberg snapshot/ migrate operation assume partition value never contains "/", this adds support for custom splitter such that user can specify a splitter that won't never conflict with partition value.

Another option is to add this as a procedure parameters, but this approach requires a lot of changes. If the change can not be pushed to upstream, will make the rebase more difficult. So decided to go with the spark session config approach instead.

Tested internally.

Unit test locally by running `./gradlew build`