### PR TITLE
[spark 3.2] skip empty file during table migration, table snapshotting or adding files (if there is a same PR on upstream, get rid of this)

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -141,7 +142,9 @@ public class TableMigrationUtil {
             index -> {
               Metrics metrics = getAvroMetrics(fileStatus.get(index).getPath(), conf);
               datafiles[index] =
-                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "avro");
+                  metrics.recordCount() > 0
+                      ? buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "avro")
+                      : null;
             });
       } else if (format.contains("parquet")) {
         task.run(
@@ -149,7 +152,10 @@ public class TableMigrationUtil {
               Metrics metrics =
                   getParquetMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
               datafiles[index] =
-                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "parquet");
+                  metrics.recordCount() > 0
+                      ? buildDataFile(
+                          fileStatus.get(index), partitionValues, spec, metrics, "parquet")
+                      : null;
             });
       } else if (format.contains("orc")) {
         task.run(
@@ -157,12 +163,15 @@ public class TableMigrationUtil {
               Metrics metrics =
                   getOrcMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
               datafiles[index] =
-                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "orc");
+                  metrics.recordCount() > 0
+                      ? buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "orc")
+                      : null;
             });
       } else {
         throw new UnsupportedOperationException("Unknown partition format: " + format);
       }
-      return Arrays.asList(datafiles);
+      return Arrays.asList(
+          Arrays.stream(datafiles).filter(Objects::nonNull).toArray(DataFile[]::new));
     } catch (IOException e) {
       throw new RuntimeException("Unable to list files in partition: " + partitionUri, e);
     } finally {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -925,12 +925,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    List<Object[]> result =
-        sql(
+    Object tableResult =
+        scalarSql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
+    Assert.assertEquals(2L, tableResult);
 
     assertEquals(
         "Iceberg table contains correct data",

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -916,6 +916,44 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
+  @Test
+  public void testSkipAddingEmptyFile() {
+    createUnpartitionedParquetFileTableWithEmptyFiles();
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+
+    sql(createIceberg, tableName);
+
+    List<Object[]> result =
+        sql(
+            "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
+            catalogName, tableName, fileTableDir.getAbsolutePath());
+
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
+
+    assertEquals(
+        "Iceberg table contains correct data",
+        sql("SELECT * FROM %s ORDER BY id", sourceTableName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  private void createUnpartitionedParquetFileTableWithEmptyFiles() {
+    String createParquet =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING %s LOCATION '%s'";
+
+    sql(createParquet, sourceTableName, "parquet", fileTableDir.getAbsolutePath());
+    unpartitionedDF.write().insertInto(sourceTableName);
+    unpartitionedDF.write().insertInto(sourceTableName);
+    int fileCount = fileTableDir.listFiles().length;
+    unpartitionedDF.limit(0).write().insertInto(sourceTableName);
+    int newFileCount = fileTableDir.listFiles().length;
+    Assert.assertEquals(
+        "There should be exactly 2 new file generated after writing empty data to the table (1 SUCCESS file, 1 empty file)",
+        2,
+        newFileCount - fileCount);
+  }
+
   private static final List<Object[]> emptyQueryResult = Lists.newArrayList();
 
   private static final StructField[] struct = {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
@@ -200,5 +201,27 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         "Should have expected rows",
         ImmutableList.of(row(1L, "2023/05/30", java.sql.Date.valueOf("2023-05-30"))),
         sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testMigrateWithEmptyFile() throws IOException {
+    Assume.assumeTrue(catalogName.equals("spark_catalog"));
+    File tempFolder = temp.newFolder();
+    String location = tempFolder.toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        tableName, location);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    int fileCount = tempFolder.listFiles().length;
+    sql("INSERT INTO TABLE %s SELECT * FROM VALUES (1, 'a') limit 0", tableName);
+    int newFileCount = tempFolder.listFiles().length;
+    Assert.assertEquals(
+        "There should be exactly 2 new file generated after writing empty data to the table (1 SUCCESS file, 1 empty file)",
+        2,
+        newFileCount - fileCount);
+
+    Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
+
+    Assert.assertEquals("Should have added one file", 1L, result);
   }
 }


### PR DESCRIPTION
This is the spark 3.2 version of https://github.com/apache/iceberg/pull/8040. Since upstream hasn't implemented yet, we will implement in our own branch first.

tested with unit test