### PR TITLE
update build for flink iceberg module and use Flink 1.15 as default to match internal Flink version

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: ${{ runner.os }}-gradle-
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc -x integrationTest
     - uses: actions/upload-artifact@v3
       if: failure()
       with:

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -31,7 +31,10 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     api project(':iceberg-data')
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
-    implementation project(':iceberg-hive-metastore')
+    implementation (project(':iceberg-hive-metastore')) {
+      exclude group: 'org.apache.hive', module: 'hive-metastore'
+      exclude group: 'org.apache.hadoop', module: 'hadoop-client'
+    }
 
     compileOnly "org.apache.flink:flink-avro:${flinkVersion}"
     // for dropwizard histogram metrics implementation
@@ -134,6 +137,10 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'org.apache.commons'
       exclude group: 'commons-pool'
       exclude group: 'commons-codec'
+      exclude group: 'commons-logging'
+      exclude group: 'commons-lang'
+      exclude group: 'commons-cli'
+      exclude group: 'commons-dbcp'
       exclude group: 'org.xerial.snappy'
       exclude group: 'javax.xml.bind'
       exclude group: 'javax.annotation'
@@ -231,6 +238,8 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.apache.httpcomponents.client5', 'org.apache.iceberg.shaded.org.apache.httpcomponents.client5'
+    relocate 'org.apache.thrift', 'org.apache.hive.org.apache.thrift'
+    relocate 'com.facebook.fb303', 'org.apache.hive.com.facebook.fb303'
 
     archiveClassifier.set(null)
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhJsonOutputPath=build/reports/jmh/results.json
 jmhIncludeRegex=.*
-systemProp.defaultFlinkVersions=1.17
+systemProp.defaultFlinkVersions=1.15
 systemProp.knownFlinkVersions=1.15,1.16,1.17
 systemProp.defaultHiveVersions=2
 systemProp.knownHiveVersions=2,3


### PR DESCRIPTION
In this PR,  I update build for flink iceberg module to match with the Flink 1.15 used internally:
1. make Flink 1.15 default version for Iceberg 1.3.x  

2. remove conflicting jars, similar as we did in 0.11.x version https://github.com/pinterest/iceberg/commit/632c0a9be30cc2e097daaa970353630b872e3a4a 

3. since we remove conflicting jars,  we need to disable integration test. Other unit tests passes and the local run result is attached. 
[local build result.txt](https://github.com/pinterest/iceberg/files/12470231/local.build.result.txt)
 
