### PR TITLE
Cache filesToImport variable to avoid duplicated compute

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -617,6 +617,7 @@ public class SparkTableUtil {
             Encoders.javaSerialization(DataFile.class));
 
     if (checkDuplicateFiles) {
+      filesToImport.cache();
       Dataset<Row> importedFiles =
           filesToImport
               .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())


### PR DESCRIPTION
Add file operation with checkDuplicateFiles being false (default case) will lead to `filesToImport` being computed multiple times, this lead to slower of add file application.